### PR TITLE
[2/2] vendor: add OTA script do delete package cache

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -54,6 +54,10 @@ PRODUCT_COPY_FILES += \
     vendor/aosp/prebuilt/common/bin/50-base.sh:system/addon.d/50-base.sh \
     vendor/aosp/prebuilt/common/bin/blacklist:system/addon.d/blacklist
 
+# Clean cache
+PRODUCT_COPY_FILES += \
+    vendor/aosp/prebuilt/common/bin/clean_cache.sh:system/bin/clean_cache.sh
+
 ifeq ($(AB_OTA_UPDATER),true)
 PRODUCT_COPY_FILES += \
     vendor/aosp/prebuilt/common/bin/backuptool_ab.sh:system/bin/backuptool_ab.sh \

--- a/prebuilt/common/bin/clean_cache.sh
+++ b/prebuilt/common/bin/clean_cache.sh
@@ -1,0 +1,10 @@
+#!/sbin/sh
+#
+# /system/bin/clean_cache.sh
+# During a firmware upgrade, this script deletes cache files
+# in /data/system/package_cache/*
+#
+
+if [ -d /data/system/package_cache/ ]; then
+    rm -fr /data/system/package_cache/*
+fi


### PR DESCRIPTION
after flashing new image delete contents of /data/system/package_cache/
to make sure they are recreated. Outdated cache files are the
reason for the famous 'resource derps'

Change-Id: Iaf1f113a64242254b8fb33bc5b9fdef0c9fdb120